### PR TITLE
added support for int key/value maps when writing http response body

### DIFF
--- a/json.go
+++ b/json.go
@@ -32,6 +32,10 @@ func (httpLogger *internalHttpLogger) jsonHttpResponse(w http.ResponseWriter, ht
 			for key, value := range xx {
 				datum[key] = value
 			}
+		case map[string]int:
+			for key, value := range xx {
+				datum[key] = value
+			}
 		case string:
 			datum["text"] = xx
 		}


### PR DESCRIPTION
I added this to support specifying integer based error codes in response bodies
